### PR TITLE
Update doxygen to v1.8.18

### DIFF
--- a/doxygen.install/doxygen.install.nuspec
+++ b/doxygen.install/doxygen.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>doxygen.install</id>
-    <version>1.8.17</version>
+    <version>1.8.18</version>
     <title>Doxygen (Install)</title>
     <authors>Dimitri van Heesch</authors>
     <owners>mlt</owners>

--- a/doxygen.install/tools/chocolateyInstall.ps1
+++ b/doxygen.install/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
   PackageName  = 'doxygen.install'
   FileType     = 'exe'
   SilentArgs   = '/VERYSILENT'
-  Url          = 'https://sourceforge.net/projects/doxygen/files/rel-1.8.17/doxygen-1.8.17-setup.exe/download'
-  Checksum     = '1ef86daf5d41f56fa62d827027dda291968cd1dc'
+  Url          = 'https://sourceforge.net/projects/doxygen/files/rel-1.8.18/doxygen-1.8.18-setup.exe/download'
+  Checksum     = 'c781783f594eadaf7f3c2983dc7f9a1c99e91c90'
   ChecksumType = 'sha1'
 }
 


### PR DESCRIPTION
Doxygen 1.8.18 was released on April 13th 2020:
https://sourceforge.net/projects/doxygen/files/